### PR TITLE
Add `codeUrl` property to webtask.json

### DIFF
--- a/webtask.json
+++ b/webtask.json
@@ -9,6 +9,7 @@
   "useHashName": false,
   "docsUrl": "https://github.com/auth0/auth0-deploy-cli/blob/master/README.md",
   "logoUrl": "http://openid.net/wordpress-content/uploads/2016/05/auth0-logo-blue.png",
+  "codeUrl": "https://raw.githubusercontent.com/auth0-extensions/auth0-deploy-cli-extension/master/index.js",
   "initialUrlPath": "/admins/login",
   "uninstallConfirmMessage": "Do you really want to uninstall this extension? Doing so will also remove the client.",
   "repository": "https://github.com/auth0-extensions/auth0-deploy-cli-extension",

--- a/webtask.json
+++ b/webtask.json
@@ -9,7 +9,7 @@
   "useHashName": false,
   "docsUrl": "https://github.com/auth0/auth0-deploy-cli/blob/master/README.md",
   "logoUrl": "http://openid.net/wordpress-content/uploads/2016/05/auth0-logo-blue.png",
-  "codeUrl": "https://raw.githubusercontent.com/auth0-extensions/auth0-deploy-cli-extension/master/index.js",
+  "codeUrl": "https://raw.githubusercontent.com/auth0-extensions/auth0-deploy-cli-extension/master/build/bundle.js",
   "initialUrlPath": "/admins/login",
   "uninstallConfirmMessage": "Do you really want to uninstall this extension? Doing so will also remove the client.",
   "repository": "https://github.com/auth0-extensions/auth0-deploy-cli-extension",


### PR DESCRIPTION
## ✏️ Changes

Add missing `codeUrl` property, allowing the extension to be installed in an Auth0 tenant.
  
## 🔗 References
  
Fixes #6 
  
## 🎯 Testing

Installed against an EU tenant (which then passed my employer's test suite)
