### PR TITLE
Use HTTPS for logoURL

### DIFF
--- a/webtask.json
+++ b/webtask.json
@@ -8,7 +8,7 @@
   "type": "application",
   "useHashName": false,
   "docsUrl": "https://github.com/auth0/auth0-deploy-cli/blob/master/README.md",
-  "logoUrl": "http://openid.net/wordpress-content/uploads/2016/05/auth0-logo-blue.png",
+  "logoUrl": "https://openid.net/wordpress-content/uploads/2016/05/auth0-logo-blue.png",
   "initialUrlPath": "/admins/login",
   "uninstallConfirmMessage": "Do you really want to uninstall this extension? Doing so will also remove the client.",
   "repository": "https://github.com/auth0-extensions/auth0-deploy-cli-extension",


### PR DESCRIPTION
ESD-4537 #comment Partial fix


## ✏️ Changes
logoUrl previously was using HTTP and causing `Not Secure` warnings in
browsers. Changed to use HTTPS. URL verified working.

## 📷 Screenshots

N/A

## 🔗 References

[ESD-4357](https://auth0team.atlassian.net/browse/ESD-4537)

## 🎯 Testing

🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
> Can this change be merged at any time? What will the deployment of the change look like? Does this need to be released in lockstep with something else?
  
✅ This can be deployed any time
  
  
## 🎡 Rollout
  
Browse to Extensions from the dashboard, check browser address bar, which should no longer show warnings on images being transferred using HTTP
  
## 🔥 Rollback
  
N/A
  
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.