### PR TITLE
[DXEX-1229] chore: marking extension deprecated

### DIFF
--- a/webtask.json
+++ b/webtask.json
@@ -1,5 +1,6 @@
 {
   "title": "Auth0 Deploy CLI",
+  "deprecated": true,
   "name": "auth0-deploy-cli-extension",
   "version": "6.0.0",
   "preVersion": "2.0.0",


### PR DESCRIPTION
## ✏️ Changes
  
Marking extension as `deprecated`
  
## 📷 Screenshots
 
n/a
  
## 🔗 References
  
https://auth0team.atlassian.net/browse/DXEX-1229
  
## 🎯 Testing
  
n/a
  
## 🚀 Deployment
  
⚠️ This should not be merged until:
  - Other condition: Public notification of deprecation has been published
  
## 🎡 Rollout
  
n/a
  
## 🔥 Rollback
  
n/a

### 📄 Procedure
  
n/a

## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
